### PR TITLE
Small change to anaconda grn.yml file

### DIFF
--- a/grn.yml
+++ b/grn.yml
@@ -20,5 +20,7 @@ dependencies:
    - python-louvain=0.13
    - umap-learn=0.3.10
    - keras=2.3.1
-   - bokeh-catplot=0.1.5
    - imbalanced-learn=0.5.0
+   - pip
+   - pip:
+      - bokeh-catplot==0.1.5


### PR DESCRIPTION
I made a small change to the anaconda environment file. bokeh-catplot isn't available through the anaconda cloud (I don't think), so to make it work I had to add pip as a requirement and then use it to download and install the package. Great tutorial by the way, I enjoyed your talk a lot!